### PR TITLE
Add: Custom HTTP Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,8 +12,9 @@ import (
 type (
 	// SkynetClient is the Skynet Client which can be used to access Skynet.
 	SkynetClient struct {
-		PortalURL string
-		Options   Options
+		PortalURL  string
+		Options    Options
+		httpClient *http.Client
 	}
 
 	// requestOptions contains the options for a request.
@@ -37,9 +38,15 @@ func NewCustom(portalURL string, customOptions Options) SkynetClient {
 	if portalURL == "" {
 		portalURL = DefaultPortalURL()
 	}
+
+	if customOptions.HttpClient == nil {
+		customOptions.HttpClient = http.DefaultClient
+	}
+
 	return SkynetClient{
-		PortalURL: portalURL,
-		Options:   customOptions,
+		PortalURL:  portalURL,
+		Options:    customOptions,
+		httpClient: customOptions.HttpClient,
 	}
 }
 
@@ -93,7 +100,7 @@ func (sc *SkynetClient) executeRequest(config requestOptions) (*http.Response, e
 	}
 
 	// Execute the request.
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := sc.httpClient.Do(req)
 	if err != nil {
 		return nil, errors.AddContext(err, "could not execute request")
 	}

--- a/utils.go
+++ b/utils.go
@@ -39,6 +39,9 @@ type (
 
 		// customContentType is the custom content type to use. Set internally.
 		customContentType string
+
+		// option to add custom http client, defaults to http.DefaultClient
+		HttpClient *http.Client
 	}
 )
 
@@ -62,6 +65,7 @@ func DefaultOptions(endpointPath string) Options {
 		EndpointPath:    endpointPath,
 		APIKey:          "",
 		CustomUserAgent: "",
+		HttpClient:      http.DefaultClient,
 	}
 }
 


### PR DESCRIPTION
Adds custom HTTP client option, defaults to `http.DefaultClient` like it was being used already

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>